### PR TITLE
Update RestTest.php

### DIFF
--- a/tests/RestTest.php
+++ b/tests/RestTest.php
@@ -4,7 +4,7 @@
  * Rest test class can work as base class for your functional tests. It provides some helpful methods to test your rest
  * api more easily.
  */
-class RestTest extends FunctionalTest {
+abstract class RestTest extends SapphireTest {
 
 
     /**


### PR DESCRIPTION
This fixes a warning thrown by phpunit and doesn't change the actual functionality of the test (you aren't really using FunctionalTest here anyway).

When I try to run the tests for this module from the commandline via phpunit (rather than /dev/tests/), I get `1) Warning: No tests found in class "FunctionalTest".` I even get this warning (which translates to a test failure) when I only run tests for my own app, one of which extends RestTest.

You don't need to extend FunctionalTest to use Director::test anyway.
